### PR TITLE
OO: Only show tooltip percent if there is an actual value to be shown

### DIFF
--- a/src/vega_viewer/vega/specs.cljs
+++ b/src/vega_viewer/vega/specs.cljs
@@ -282,9 +282,6 @@
                                        "normalize")
                              (assoc-in [:scales 1 :domainMax] 1)
                              (assoc-in [:axes 1 :format] "%")
-                             (update-in [:marks 1 :marks 1 :properties
-                                         :update :text]
-                                        dissoc :signal)
                              (assoc-in [:marks 1 :marks 1 :properties
                                         :update :text]
                                        {:rule
@@ -292,7 +289,7 @@
                                           {:name "tooltipVisible"}}
                                          {:template
                                           "{{tooltipData.frequency}} %"}]})
-                             (show-percent-sign-on-tooltip 1)))
+                             (show-percent-sign-on-tooltip 1))
                             %)]
     (-> stacked-horizontal-bar-chart-spec-template
         (assoc-in [:data 0 :values] data)

--- a/src/vega_viewer/vega/specs.cljs
+++ b/src/vega_viewer/vega/specs.cljs
@@ -285,7 +285,14 @@
                              (update-in [:marks 1 :marks 1 :properties
                                          :update :text]
                                         dissoc :signal)
-                             (show-percent-sign-on-tooltip 1))
+                             (assoc-in [:marks 1 :marks 1 :properties
+                                        :update :text]
+                                       {:rule
+                                        [{:predicate
+                                          {:name "tooltipVisible"}}
+                                         {:template
+                                          "{{tooltipData.frequency}} %"}]})
+                             (show-percent-sign-on-tooltip 1)))
                             %)]
     (-> stacked-horizontal-bar-chart-spec-template
         (assoc-in [:data 0 :values] data)


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/onaio/vega-viewer/pull/22 that made a percentage sign appear without a tooltip when hovering between bars plus a bit of cleanup I missed during review.
