### PR TITLE
Check if "signals" list is present before modification

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onaio/vega-viewer "0.3.3"
+(defproject onaio/vega-viewer "0.4.0"
   :description "Om component that renders a vega chart from a spec"
   :url "https://github.com/onaio/vega-viewer"
   :license {:name "Eclipse Public License"

--- a/src/vega_viewer/vega/specs/utils.cljs
+++ b/src/vega_viewer/vega/specs/utils.cljs
@@ -70,21 +70,24 @@
                     {:template "{{tooltipData.frequency}} %"}]}))
 
 (defn set-tooltip-bounds
-  [spec & {:keys [visualization-height visualization-width]}]
-  (let [signal-index (cond
-                       visualization-height 2
-                       visualization-width 1)
-        event-fn-literal (cond
-                           visualization-height "eventY()"
-                           visualization-width "eventX()")]
-    (assoc-in spec [:signals signal-index :streams 0 :expr]
-              (str "min("
-                   (when visualization-width
-                     (- visualization-width
-                        tooltip-width))
-                   (when visualization-height
-                     (- visualization-height
-                        tooltip-height))
-                   ","
-                   event-fn-literal
-                   ")"))))
+  [{:keys [signals] :as spec}
+   & {:keys [visualization-height visualization-width]}]
+  (if signals
+    (let [signal-index (cond
+                         visualization-height 2
+                         visualization-width 1)
+          event-fn-literal (cond
+                             visualization-height "eventY()"
+                             visualization-width "eventX()")]
+      (assoc-in spec [:signals signal-index :streams 0 :expr]
+                (str "min("
+                     (when visualization-width
+                       (- visualization-width
+                          tooltip-width))
+                     (when visualization-height
+                       (- visualization-height
+                          tooltip-height))
+                     ","
+                     event-fn-literal
+                     ")")))
+    spec))


### PR DESCRIPTION
Calling set-tooltip-bounds leads to an inconsistent state if called on a spec lacking a signals key.
