### PR TITLE
Set x-axis chart labels diagonally for grouped charts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onaio/vega-viewer "0.8.5-SNAPSHOT"
+(defproject onaio/vega-viewer "0.8.5"
   :description "Om component that renders a vega chart from a spec"
   :url "https://github.com/onaio/vega-viewer"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onaio/vega-viewer "0.8.4"
+(defproject onaio/vega-viewer "0.8.5-SNAPSHOT"
   :description "Om component that renders a vega chart from a spec"
   :url "https://github.com/onaio/vega-viewer"
   :license {:name "Eclipse Public License"

--- a/src/vega_viewer/vega/specs/grouped_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/grouped_bar_chart.cljs
@@ -128,7 +128,6 @@
                     :offset -6.5
                     :orient "bottom"
                     :tickSize 5
-                    :z-index 1
                     :properties {:axis {:strokeWidth {:value 1}}
                                  :labels {:angle {:value 300}
                                           :dx {:value 0}

--- a/src/vega_viewer/vega/specs/grouped_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/grouped_bar_chart.cljs
@@ -125,10 +125,15 @@
                                :sort true}}]
             :axes [{:type "x"
                     :scale "column"
-                    :offset -8
+                    :offset -6.5
                     :orient "bottom"
                     :tickSize 5
-                    :properties {:axis {:strokeWidth {:value 1}}}}]
+                    :z-index 1
+                    :properties {:axis {:strokeWidth {:value 1}}
+                                 :labels {:angle {:value 300}
+                                          :dx {:value 0}
+                                          :dy {:value -7}
+                                          :align {:value "right"}}}}]
             :legends [{:fill "color"
                        :properties {:symbols {:shape {:value "circle"}
                                               :strokeWidth {:value 0}}}}]}]})


### PR DESCRIPTION
The labels on the x-axis overlap in grouped charts. This changes the x-axis labels by rotating 300 degrees and setting the offset from the x-axis to 0px and to the y-axis to -7px.