### PR TITLE
[DNM] Stacked bar chart for displaying three variables charts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onaio/vega-viewer "0.8.8"
+(defproject onaio/vega-viewer "0.8.9-SNAPSHOT"
   :description "Om component that renders a vega chart from a spec"
   :url "https://github.com/onaio/vega-viewer"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject onaio/vega-viewer "0.8.9-SNAPSHOT"
+(defproject onaio/vega-viewer "0.9.0-SNAPSHOT"
   :description "Om component that renders a vega chart from a spec"
   :url "https://github.com/onaio/vega-viewer"
   :license {:name "Eclipse Public License"

--- a/src/vega_viewer/components/stacked_bar_chart.cljs
+++ b/src/vega_viewer/components/stacked_bar_chart.cljs
@@ -1,0 +1,18 @@
+(ns vega-viewer.components.stacked-bar-chart
+  (:require [om.core :as om :include-macros true]
+            [sablono.core :refer-macros [html]]
+            [vega-viewer.components.vega-viewer :refer [vega-viewer]]
+            [vega-viewer.vega.specs.stacked-bar-chart
+             :refer [generate-stacked-bar-chart-vega-spec]]))
+
+(defn stacked-bar-chart
+  [cursor owner {:keys [user-defined-palette]
+                 :as opts}]
+  (reify
+    om/IRender
+    (render [_]
+      (let [vega-spec
+            (generate-stacked-bar-chart-vega-spec cursor
+                                                  :user-defined-palette
+                                                  user-defined-palette)]
+        (html (om/build vega-viewer vega-spec {:opts opts}))))))

--- a/src/vega_viewer/vega/specs/grouped_stacked_chart.cljs
+++ b/src/vega_viewer/vega/specs/grouped_stacked_chart.cljs
@@ -103,7 +103,7 @@
                               :from {:transform [{:type "stack"
                                                   :groupby ["x"]
                                                   :field "sum_y"
-                                                  :sortby ["-z"]
+                                                  :sortby ["z"]
                                                   :output
                                                   {:start "sum_y_start"
                                                    :end "sum_y_end"}

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -31,7 +31,6 @@
              :domain {:data "stats" :field "sum_y"}}
             {:name "color"
              :type "ordinal"
-             :range "category10"
              :domain {:data "table" :field "z"}}]
    :axes [{:type "x"
            :scale "x"}
@@ -56,27 +55,27 @@
                          {:fillOpacity {:value 1}}
                          :hover
                          {:fillOpacity {:value 0.5}}}}
-             {:type "group"
-                :properties {:enter {:align {:value "center"}
-                                        :fill {:value "#fff"}}
-                                :update {:y {:signal "tooltipY"
-                                        :offset tooltip-offset}
-                                        :x {:signal "tooltipX"
-                                        :offset tooltip-offset}
-                                        :height {:rule
-                                                [{:predicate
-                                                {:name "isTooltipVisible?"}
-                                                :value 0}
-                                                {:value tooltip-height}]}
-                                        :width {:value tooltip-width}
-                                        :fillOpacity {:value tooltip-opacity}
-                                        :stroke {:value tooltip-stroke-color}
-                                        :strokeWidth
-                                        {:rule
-                                        [{:predicate {:name "isTooltipVisible?"}
-                                        :value 0}
-                                        {:value 1}]}}}
-                :marks (get-tooltip-text-marks {:label-field "z"
+           {:type "group"
+            :properties {:enter {:align {:value "center"}
+                                 :fill {:value "#fff"}}
+                         :update {:y {:signal "tooltipY"
+                                      :offset tooltip-offset}
+                                  :x {:signal "tooltipX"
+                                      :offset tooltip-offset}
+                                  :height {:rule
+                                           [{:predicate
+                                             {:name "isTooltipVisible?"}
+                                             :value 0}
+                                            {:value tooltip-height}]}
+                                  :width {:value tooltip-width}
+                                  :fillOpacity {:value tooltip-opacity}
+                                  :stroke {:value tooltip-stroke-color}
+                                  :strokeWidth
+                                  {:rule
+                                   [{:predicate {:name "isTooltipVisible?"}
+                                     :value 0}
+                                    {:value 1}]}}}
+            :marks (get-tooltip-text-marks {:label-field "z"
                                             :value-field "y"})}]
    :signals [{:name "tooltipData"
               :init {}
@@ -104,8 +103,8 @@
     (-> stacked-bar-chart-spec-template
         (assoc-in [:data 0 :values] data)
         (assoc :height chart-height :width chart-width)
-        (assoc-in [:marks 0 :scales 2 :range] (or (seq user-defined-palette)
-                                                  palette))
+        (assoc-in [:scales 2 :range] (or (seq user-defined-palette)
+                                         palette))
         (set-tooltip-bounds :visualization-height chart-height)
         (set-tooltip-bounds :visualization-width chart-width)
         (set-status-text status-text chart-height)

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -18,8 +18,13 @@
           {:name "stats"
            :source "table"
            :transform [{:type "aggregate"
-                        :groupby ["x"]
-                        :summarize [{:field "y" :ops ["sum"]}]}]}]
+                        :groupby ["x","z"]
+                        :summarize {:y ["sum"]}}]}
+          {:name "stacked_scale"
+           :source "stats"
+           :transform [{:type "aggregate"
+                        :summarize [{:ops ["sum"], :field "sum_y"}]
+                        :groupby ["x"]}]}]
    :scales [{:name "x"
              :type "ordinal"
              :range "width"
@@ -28,10 +33,10 @@
              :type "linear"
              :range "height"
              :nice true
-             :domain {:data "stats" :field "sum_y"}}
+             :domain {:data "stacked_scale" :field "sum_sum_y"}}
             {:name "color"
              :type "ordinal"
-             :domain {:data "table" :field "z"}}]
+             :domain {:data "stats" :field "z"}}]
    :axes [{:type "x"
            :scale "x"}
           {:type "y"
@@ -40,43 +45,46 @@
               :properties {:symbols {:shape {:value "circle"}
                                      :strokeWidth {:value 0}}}}]
    :marks [{:type "rect"
-            :from {:data "table"
+            :from {:data "stats"
                    :transform [{:type "stack"
                                 :groupby ["x"]
-                                :field "y"
-                                :sortby ["z"]}]}
+                                :field "sum_y"
+                                :sortby ["z"]
+                                :output {:start "sum_y_start"
+                                         :end "sum_y_end"}
+                                :offset "zero"}]}
             :properties {:enter
-                         {:x {:scale "x" :field "x"}
+                         {:x {:scale "x" :field "x" :offset 3}
                           :width {:scale "x" :band true :offset -3}
-                          :y {:scale "y" :field "layout_start"}
-                          :y2 {:scale "y" :field "layout_end"}
+                          :y {:scale "y" :field "sum_y_start"}
+                          :y2 {:scale "y" :field "sum_y_end"}
                           :fill {:scale "color" :field "z"}}
                          :update
                          {:fillOpacity {:value 1}}
                          :hover
                          {:fillOpacity {:value 0.5}}}}
-             {:type "group"
-                :properties {:enter {:align {:value "center"}
-                                        :fill {:value "#fff"}}
-                                :update {:y {:signal "tooltipY"
-                                        :offset tooltip-offset}
-                                        :x {:signal "tooltipX"
-                                        :offset tooltip-offset}
-                                        :height {:rule
-                                                [{:predicate
-                                                {:name "isTooltipVisible?"}
-                                                :value 0}
-                                                {:value tooltip-height}]}
-                                        :width {:value tooltip-width}
-                                        :fillOpacity {:value tooltip-opacity}
-                                        :stroke {:value tooltip-stroke-color}
-                                        :strokeWidth
-                                        {:rule
-                                        [{:predicate {:name "isTooltipVisible?"}
-                                        :value 0}
-                                        {:value 1}]}}}
-                :marks (get-tooltip-text-marks {:label-field "z"
-                                            :value-field "y"})}]
+           {:type "group"
+            :properties {:enter {:align {:value "center"}
+                                 :fill {:value "#fff"}}
+                         :update {:y {:signal "tooltipY"
+                                      :offset tooltip-offset}
+                                  :x {:signal "tooltipX"
+                                      :offset tooltip-offset}
+                                  :height {:rule
+                                           [{:predicate
+                                             {:name "isTooltipVisible?"}
+                                             :value 0}
+                                            {:value tooltip-height}]}
+                                  :width {:value tooltip-width}
+                                  :fillOpacity {:value tooltip-opacity}
+                                  :stroke {:value tooltip-stroke-color}
+                                  :strokeWidth
+                                  {:rule
+                                   [{:predicate {:name "isTooltipVisible?"}
+                                     :value 0}
+                                    {:value 1}]}}}
+            :marks (get-tooltip-text-marks {:label-field "z"
+                                            :value-field "sum_y"})}]
    :signals [{:name "tooltipData"
               :init {}
               :streams [{:type "rect:mouseover" :expr "datum"}
@@ -104,7 +112,7 @@
         (assoc-in [:data 0 :values] data)
         (assoc :height chart-height :width chart-width)
         (assoc-in [:scales 2 :range] (or (seq user-defined-palette)
-                                                  palette))
+                                         palette))
         (set-tooltip-bounds :visualization-height chart-height)
         (set-tooltip-bounds :visualization-width chart-width)
         (set-status-text status-text chart-height)

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -36,7 +36,7 @@
              :domain {:data "stacked_scale" :field "sum_sum_y"}}
             {:name "color"
              :type "ordinal"
-             :domain {:data "stats" :field "z"}}]
+             :domain {:data "table" :field "z"}}]
    :axes [{:type "x"
            :scale "x"}
           {:type "y"
@@ -84,7 +84,7 @@
                                      :value 0}
                                     {:value 1}]}}}
             :marks (get-tooltip-text-marks {:label-field "z"
-                                            :value-field "sum_y"})}]
+                                            :value-field "y"})}]
    :signals [{:name "tooltipData"
               :init {}
               :streams [{:type "rect:mouseover" :expr "datum"}

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -31,7 +31,6 @@
              :domain {:data "stats" :field "sum_y"}}
             {:name "color"
              :type "ordinal"
-             :range "category10"
              :domain {:data "table" :field "z"}}]
    :axes [{:type "x"
            :scale "x"}
@@ -104,7 +103,7 @@
     (-> stacked-bar-chart-spec-template
         (assoc-in [:data 0 :values] data)
         (assoc :height chart-height :width chart-width)
-        (assoc-in [:marks 0 :scales 2 :range] (or (seq user-defined-palette)
+        (assoc-in [:scales 2 :range] (or (seq user-defined-palette)
                                                   palette))
         (set-tooltip-bounds :visualization-height chart-height)
         (set-tooltip-bounds :visualization-width chart-width)

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -84,7 +84,7 @@
                                      :value 0}
                                     {:value 1}]}}}
             :marks (get-tooltip-text-marks {:label-field "z"
-                                            :value-field "y"})}]
+                                            :value-field "sum_y"})}]
    :signals [{:name "tooltipData"
               :init {}
               :streams [{:type "rect:mouseover" :expr "datum"}

--- a/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
+++ b/src/vega_viewer/vega/specs/stacked_bar_chart.cljs
@@ -1,0 +1,89 @@
+(ns vega-viewer.vega.specs.stacked-bar-chart
+  (:require [vega-viewer.vega.specs.constants
+             :refer [band-width bar-color bar-height bar-height-offset
+                     default-chart-width palette tooltip-height
+                     tooltip-width tooltip-offset tooltip-opacity
+                     tooltip-stroke-color y-offset max-height]]
+            [vega-viewer.vega.specs.utils
+             :refer [get-tooltip-text-marks
+                     set-status-text
+                     chart-title-text
+                     set-tooltip-bounds
+                     show-percent-sign-on-tooltip
+                     truncate-y-axis-labels]]))
+
+(def stacked-bar-chart-spec-template
+  {:data [{:name "table"
+           :values [{"x" "bangaladesh" "y" 292 "c" "Cynthia Akinyi"}
+                    {"x" "bangaladesh" "y" 303 "c" "Fatuma Mwakusema"}
+                    {"x" "bangaladesh" "y" 193 "c" "Gibson Kea"}
+                    {"x" "bangaladesh" "y" 252 "c" "Grace Nyambu"}
+                    {"x" "bangaladesh" "y" 342 "c" "Jane Kabui"}
+                    {"x" "bangaladesh" "y" 216 "c" "Joseph Ondiso"}
+                    {"x" "bangaladesh" "y" 260 "c" "Leonard Lector"}
+                    {"x" "bangaladesh" "y" 153 "c" "Peris Wambui"}
+                    {"x" "moroto" "y" 294 "c" "Andrew Mweteeli"}
+                    {"x" "moroto" "y" 183 "c" "Angeline Kache"}
+                    {"x" "moroto" "y" 231 "c" "Donald Akutoi"}
+                    {"x" "moroto" "y" 188 "c" "Fauzia  Shivisi"}
+                    {"x" "moroto" "y" 207 "c" "Kimm Nauli"}
+                    {"x" "moroto" "y" 356 "c" "Penina Muthoki"}
+                    {"x" "moroto" "y" 167 "c" "Teresia Wangeci"}]}
+          {:name "stats"
+           :source "table"
+           :transform [{:type "aggregate"
+                        :groupby ["x"]
+                        :summarize [{:field "y" :ops ["sum"]}]}]}]
+   :scales [{:name "x"
+             :type "ordinal"
+             :range "width"
+             :domain {:data "table" :field "x"}}
+            {:name "y"
+             :type "linear"
+             :range "height"
+             :nice true
+             :domain {:data "stats" :field "sum_y"}}
+            {:name "color"
+             :type "ordinal"
+             :range "category10"
+             :domain {:data "table" :field "c"}}]
+   :axes [{:type "x"
+           :scale "x"}
+          {:type "y"
+           :scale "y"}]
+   :legends [{:fill "color"
+              :properties {:symbols {:shape {:value "circle"}
+                                     :strokeWidth {:value 0}}}}]
+   :marks [{:type "rect"
+            :from {:data "table"
+                   :transform [{:type "stack"
+                                :groupby ["x"]
+                                :field "y"
+                                :sortby ["c"]}]}
+            :properties {:enter
+                         {:x {:scale "x" :field "x"}
+                          :width {:scale "x" :band true :offset -3}
+                          :y {:scale "y" :field "layout_start"}
+                          :y2 {:scale "y" :field "layout_end"}
+                          :fill {:scale "color" :field "c"}}
+                         :update
+                         {:fillOpacity {:value 1}}
+                         :hover
+                         {:fillOpacity {:value 0.5}}}}]})
+
+(defn generate-stacked-bar-chart-vega-spec
+  [{:keys [data height width status-text chart-text
+           maximum-y-axis-label-length]}
+   & {:keys [responsive? user-defined-palette]}]
+  (let [chart-height (min (or height (* (count data) band-width)) max-height)
+        chart-width (or width
+                        (and (not responsive?)
+                             default-chart-width))]
+    (-> stacked-bar-chart-spec-template
+        ;; (assoc-in [:data 0 :values] data)
+        (assoc :height chart-height :width chart-width)
+        (assoc-in [:marks 0 :scales 2 :range] (or (seq user-defined-palette)
+                                                  palette))
+        (set-status-text status-text chart-height)
+        (chart-title-text chart-text chart-height)
+        (truncate-y-axis-labels maximum-y-axis-label-length))))

--- a/test/test_runner.cljs
+++ b/test/test_runner.cljs
@@ -7,7 +7,8 @@
             [vega-viewer.vega.specs.grouped-bar-chart-test]
             [vega-viewer.vega.specs.grouped-stacked-chart-test]
             [vega-viewer.vega.specs.horizontal-bar-chart-test]
-            [vega-viewer.vega.specs.stacked-horizontal-bar-chart-test]))
+            [vega-viewer.vega.specs.stacked-horizontal-bar-chart-test]
+            [vega-viewer.vega.specs.stacked-bar-chart-test]))
 
 (enable-console-print!)
 
@@ -25,6 +26,7 @@
         'vega-viewer.vega.specs.grouped-bar-chart-test
         'vega-viewer.vega.specs.grouped-stacked-chart-test
         'vega-viewer.vega.specs.horizontal-bar-chart-test
-        'vega-viewer.vega.specs.stacked-horizontal-bar-chart-test))
+        'vega-viewer.vega.specs.stacked-horizontal-bar-chart-test
+        'vega-viewer.vega.specs.stacked-bar-chart-test))
     0
     1))

--- a/test/vega_viewer/vega/specs/stacked_bar_chart_test.cljs
+++ b/test/vega_viewer/vega/specs/stacked_bar_chart_test.cljs
@@ -1,0 +1,16 @@
+(ns vega-viewer.vega.specs.stacked-bar-chart-test
+  (:require-macros [cljs.test :refer [deftest testing]])
+  (:require [vega-viewer.vega.specs-test-utils
+             :refer [test-validity]]
+            [vega-viewer.vega.specs.stacked-bar-chart
+             :refer [generate-stacked-bar-chart-vega-spec]]))
+
+(deftest stacked-bar-chart-spec-is-vega-compliant
+  (let [data  [{"x" "bangaladesh" "y" 292  "z" "Cynthia Akinyi"}
+               {"x" "bangaladesh" "y" 303 "z" "Fatuma Mwakusema"}
+               {"x" "bangaladesh" "y" 193 "z" "Gibson Kea"}
+               {"x" "moroto" "y" 183 "z" "Angeline Kache"}
+               {"x" "moroto"  "y" 231 "z" "Donald Akutoi"}]]
+    (testing "generated stacked bar chart spec is vega compliant"
+      (let [spec (generate-stacked-bar-chart-vega-spec {:data data})]
+        (test-validity spec)))))


### PR DESCRIPTION
Fixes https://github.com/onaio/zebra/issues/5081

### Changes proposed in this pull requested
- Charts with three variables where the third grouping variable has more than seven values, should display properly without the legend and bars overlapping.

### Changes this new chart will bring
- Display three variable charts, `only the overlapping one's` in a stacked manner so that there is no overlapping.
- Here is an example of how this chart will displays data:

![screen shot 2017-11-09 at 5 55 08 pm](https://user-images.githubusercontent.com/26594465/32711847-2a528bf8-c852-11e7-932d-cb52d699ec84.png)


- Here is how the same data was being displayed:

![screen shot 2017-11-09 at 5 53 30 pm](https://user-images.githubusercontent.com/26594465/32711855-38fdc456-c852-11e7-8e0d-99d172a29c3b.png)

### Blockers
None